### PR TITLE
Fix Spot arm WBC frame/joint mapping and hold arm in stowed pose

### DIFF
--- a/tbai_mpc/src/quadruped_arm_wbc/HqpWbc.cpp
+++ b/tbai_mpc/src/quadruped_arm_wbc/HqpWbc.cpp
@@ -27,8 +27,9 @@ std::vector<tbai::MotorCommand> HqpWbc::getMotorCommands(scalar_t currentTime, c
 
     // HQP task hierarchy with arm:
     // Priority 1: Dynamics + contact constraints + leg torque limits + arm torque limits
+    // Temporary test mode: disable arm EE tracking and keep only joint-space centering for the arm.
     // Priority 2: Swing foot tracking (if any swing legs)
-    // Priority 3: Base tracking + Arm EE tracking
+    // Priority 3: Base tracking
     // Priority 4: Arm joint centering (nullspace)
     // Priority 5: Contact force minimization
 
@@ -37,9 +38,7 @@ std::vector<tbai::MotorCommand> HqpWbc::getMotorCommands(scalar_t currentTime, c
         // All feet in contact: no swing leg task
         Task task1 = createDynamicsTask() + createStanceFootNoMotionTask() + createContactForceTask() +
                      createTorqueLimitTask() + createArmTorqueLimitTask();
-        Task task2 = createBaseAccelerationTask(currentState, desiredState, desiredInput, desiredJointAcceleration) +
-                     createArmEndEffectorPositionTask(desiredArmEEPosition) +
-                     createArmEndEffectorOrientationTask(desiredArmEEOrientation);
+        Task task2 = createBaseAccelerationTask(currentState, desiredState, desiredInput, desiredJointAcceleration);
         Task task3 = createArmJointCenteringTask();
         Task task4 = createContactForceMinimizationTask(desiredInput);
         std::vector<Task *> tasks = {&task1, &task2, &task3, &task4};
@@ -49,9 +48,7 @@ std::vector<tbai::MotorCommand> HqpWbc::getMotorCommands(scalar_t currentTime, c
         Task task1 = createDynamicsTask() + createStanceFootNoMotionTask() + createContactForceTask() +
                      createTorqueLimitTask() + createArmTorqueLimitTask();
         Task task2 = createSwingFootAccelerationTask(currentState, currentInput, desiredState, desiredInput);
-        Task task3 = createBaseAccelerationTask(currentState, desiredState, desiredInput, desiredJointAcceleration) +
-                     createArmEndEffectorPositionTask(desiredArmEEPosition) +
-                     createArmEndEffectorOrientationTask(desiredArmEEOrientation);
+        Task task3 = createBaseAccelerationTask(currentState, desiredState, desiredInput, desiredJointAcceleration);
         Task task4 = createArmJointCenteringTask();
         Task task5 = createContactForceMinimizationTask(desiredInput);
         std::vector<Task *> tasks = {&task1, &task2, &task3, &task4, &task5};
@@ -109,14 +106,15 @@ std::vector<tbai::MotorCommand> HqpWbc::getMotorCommands(scalar_t currentTime, c
     }
 
     // Arm joint commands (6 joints)
+    // Temporary test mode: hold the arm directly at the stowed joint configuration.
     for (size_t i = 0; i < numArmJoints; ++i) {
         tbai::MotorCommand command;
         command.joint_name = jointNames_[numLegJoints + i];
-        command.desired_position = qDesired[numLegJoints + i];
-        command.desired_velocity = vDesired[numLegJoints + i];
+        command.desired_position = armJointHomePosition_[i];
+        command.desired_velocity = 0.0;
         command.kp = armJointKp_;
         command.kd = armJointKd_;
-        command.torque_ff = armTorques[i];
+        command.torque_ff = 0.0;
         commands[numLegJoints + i] = std::move(command);
     }
 

--- a/tbai_mpc/src/quadruped_arm_wbc/SqpWbc.cpp
+++ b/tbai_mpc/src/quadruped_arm_wbc/SqpWbc.cpp
@@ -32,14 +32,12 @@ std::vector<tbai::MotorCommand> SqpWbc::getMotorCommands(scalar_t currentTime, c
         constraints = constraints + createStanceFootNoMotionTask();  // additional constraints for stance
     }
 
-    // QP cost function: base tracking + swing foot + contact force + arm EE tracking + arm joint centering
+    // Temporary test mode: disable arm EE tracking and keep only joint-space centering for the arm.
     Task weightedTasks =
         createBaseAccelerationTask(currentState, desiredState, desiredInput, desiredJointAcceleration) *
             weightBaseAcceleration_ +
         createContactForceMinimizationTask(desiredInput) * weightContactForce_ +
         createSwingFootAccelerationTask(currentState, currentInput, desiredState, desiredInput) * weightSwingLeg_ +
-        createArmEndEffectorPositionTask(desiredArmEEPosition) * weightArmEEPosition_ +
-        createArmEndEffectorOrientationTask(desiredArmEEOrientation) * weightArmEEOrientation_ +
         createArmJointCenteringTask() * weightArmJointCentering_;
 
     // solve QP
@@ -96,14 +94,15 @@ std::vector<tbai::MotorCommand> SqpWbc::getMotorCommands(scalar_t currentTime, c
     }
 
     // Arm joint commands (6 joints)
+    // Temporary test mode: hold the arm directly at the stowed joint configuration.
     for (size_t i = 0; i < numArmJoints; ++i) {
         tbai::MotorCommand command;
         command.joint_name = jointNames_[numLegJoints + i];
-        command.desired_position = qDesired[numLegJoints + i];
-        command.desired_velocity = vDesired[numLegJoints + i];
+        command.desired_position = armJointHomePosition_[i];
+        command.desired_velocity = 0.0;
         command.kp = armJointKp_;
         command.kd = armJointKd_;
-        command.torque_ff = armTorques[i];
+        command.torque_ff = 0.0;
         commands[numLegJoints + i] = std::move(command);
     }
 

--- a/tbai_mpc/src/quadruped_arm_wbc/WbcBase.cpp
+++ b/tbai_mpc/src/quadruped_arm_wbc/WbcBase.cpp
@@ -4,6 +4,7 @@
 #include <boost/property_tree/ptree.hpp>
 #include <ocs2_core/misc/LoadData.h>
 #include <pinocchio/fwd.hpp>
+#include <stdexcept>
 #include <tbai_mpc/quadruped_arm_mpc/core/MotionPhaseDefinition.h>
 #include <tbai_mpc/quadruped_arm_mpc/core/Rotations.h>
 #include <tbai_mpc/quadruped_arm_mpc/quadruped_models/QuadrupedCom.h>
@@ -43,10 +44,8 @@ WbcBase::WbcBase(const std::string &configFile, const std::string &urdfString,
     armJointNames_ = {"arm_sh0", "arm_sh1", "arm_el0", "arm_el1", "arm_wr0", "arm_wr1"};
 
     // All joint names (legs + arm)
-    jointNames_ = {"front_left_hip_x", "front_left_hip_y", "front_left_knee", "front_right_hip_x", "front_right_hip_y",
-                   "front_right_knee", "rear_left_hip_x",  "rear_left_hip_y", "rear_left_knee",    "rear_right_hip_x",
-                   "rear_right_hip_y", "rear_right_knee",  "arm_sh0",         "arm_sh1",           "arm_el0",
-                   "arm_el1",          "arm_wr0",          "arm_wr1"};
+    jointNames_ = {"LF_HAA", "LF_HFE", "LF_KFE", "RF_HAA", "RF_HFE", "RF_KFE", "LH_HAA", "LH_HFE", "LH_KFE",
+                   "RH_HAA", "RH_HFE", "RH_KFE", "arm_sh0", "arm_sh1", "arm_el0", "arm_el1", "arm_wr0", "arm_wr1"};
 
     Jcontact_ = matrix_t(3 * tbai::mpc::quadruped_arm::NUM_CONTACT_POINTS, nGeneralizedCoordinates_);
     dJcontactdt_ = matrix_t(3 * tbai::mpc::quadruped_arm::NUM_CONTACT_POINTS, nGeneralizedCoordinates_);
@@ -55,9 +54,26 @@ WbcBase::WbcBase(const std::string &configFile, const std::string &urdfString,
     Jarm_ = matrix_t(6, nGeneralizedCoordinates_);
     dJarmdt_ = matrix_t(6, nGeneralizedCoordinates_);
 
+    // Resolve the arm tip from config so the WBC matches the arm frame used by MPC kinematics.
+    std::string armEEFrameName = "arm_ee";
+    try {
+        boost::property_tree::ptree pt;
+        boost::property_tree::read_info(configFile, pt);
+        armEEFrameName = pt.get<std::string>(configPrefix + "armEEFrame", armEEFrameName);
+    } catch (...) {
+        // Fall back to the default frame name.
+    }
+
     // Get arm end-effector frame ID
     const auto &model = pinocchioInterfaceMeasured_.getModel();
-    armEEFrameId_ = model.getBodyId("arm_ee");
+    if (model.existBodyName(armEEFrameName)) {
+        armEEFrameId_ = model.getBodyId(armEEFrameName);
+    } else if (model.existJointName(armEEFrameName)) {
+        armEEFrameId_ = model.getFrameId(armEEFrameName, pinocchio::JOINT);
+    } else {
+        throw std::runtime_error("[quadruped_arm_wbc] Arm end-effector frame '" + armEEFrameName +
+                                 "' does not exist in the model.");
+    }
 
     loadSettings(configFile, configPrefix);
 }
@@ -637,7 +653,7 @@ void WbcBase::loadSettings(const std::string &configFile, const std::string &con
     loadCppDataType<scalar_t>(configFile, configPrefix + "armJointKd", armJointKd_);
 
     // Arm home position (stowed position for spot arm)
-    armJointHomePosition_ << 0.0, -3.1, 2.1, 0.0, 0.0, 0.0;
+    armJointHomePosition_ << 0.0, -3.1, 3.0, 0.0, 0.0, 0.0;
 
     // Try to load from config (if available)
     boost::property_tree::ptree pt;


### PR DESCRIPTION
This PR fixes several Spot Arm WBC inconsistencies and adds a temporary stowed-arm hold mode that makes the arm behavior stable during the transition to MPC+WBC.

Changes

- make the arm EE frame configurable in `quadruped_arm_wbc/WbcBase.cpp` instead of hardcoding `arm_ee`
- allow WBC to use the same arm tip frame as the MPC side (`arm_link_fngr` for Spot Arm)
- replace hardcoded leg joint names with Spot-compatible joint names in `jointNames_`
- align the default stowed arm configuration to:
  `0.0, -3.1, 3.0, 0.0, 0.0, 0.0`
- temporarily disable arm EE tracking inside SQP/HQP WBC
- temporarily override the final arm motor commands so the arm is held directly at the stowed joint configuration

Why

Before these changes:
- MPC and WBC could use different arm EE frames (`arm_link_fngr` vs `arm_ee`)
- WBC used legacy leg joint names that do not match Spot/Gazebo
- the arm could move away from the intended stowed pose even when the desired behavior was to keep it parked

Notes

The direct hold of the final arm command is a temporary workaround intended to keep the arm in a known stowed configuration.
This does not prevent future arm tasks; it can later be replaced by a proper Cartesian or joint-space reference pipeline once the desired arm behavior is defined.